### PR TITLE
Fix PaperClickTp

### DIFF
--- a/src/main/java/mathax/client/systems/modules/Modules.java
+++ b/src/main/java/mathax/client/systems/modules/Modules.java
@@ -453,6 +453,7 @@ public class Modules extends System<Modules> {
         add(new NoRotate());
         add(new RainbowArmor());
         //add(new PacketMine());
+        add(new PaperClickTp());
         add(new Portals());
         add(new InventoryScroll());
         add(new HeadRoll());

--- a/src/main/java/mathax/client/systems/modules/player/PaperClickTp.java
+++ b/src/main/java/mathax/client/systems/modules/player/PaperClickTp.java
@@ -1,5 +1,3 @@
-/*
-
 package mathax.client.systems.modules.player;
 
 import mathax.client.eventbus.EventHandler;
@@ -7,12 +5,11 @@ import mathax.client.events.render.Render3DEvent;
 import mathax.client.renderer.ShapeMode;
 import mathax.client.settings.*;
 import mathax.client.systems.modules.Categories;
-import mathax.client.systems.modules.Category;
 import mathax.client.systems.modules.Module;
+import mathax.client.utils.misc.KeyBind;
 import mathax.client.utils.player.GotoUtil;
 import mathax.client.utils.render.color.SettingColor;
 import net.minecraft.client.render.Camera;
-import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
@@ -35,7 +32,7 @@ public class PaperClickTp extends Module {
         .name("shape-mode")
         .description("How the shapes are rendered.")
         .defaultValue(ShapeMode.Both)
-        .visible(() -> render.get())
+        .visible(render::get)
         .build()
     );
 
@@ -43,7 +40,7 @@ public class PaperClickTp extends Module {
         .name("side-color-solid-block")
         .description("The color of the sides of the blocks being rendered.")
         .defaultValue(new SettingColor(255, 0, 255, 15))
-        .visible(() -> render.get())
+        .visible(render::get)
         .build()
     );
 
@@ -51,15 +48,18 @@ public class PaperClickTp extends Module {
         .name("line-color-solid-block")
         .description("The color of the lines of the blocks being rendered.")
         .defaultValue(new SettingColor(255, 0, 255, 255))
-        .visible(() -> render.get())
+        .visible(render::get)
         .build()
     );
     //cant resolve keybind
-    private final Setting<Keybind> cancelBlink = sgGeneral.add(new KeybindSetting.Builder()
+    //classes are case-sensitive, Keybind doesn't work, but KeyBind does (notice the capital B)
+    @SuppressWarnings("unused")
+    private final Setting<KeyBind> cancelBlink = sgGeneral.add(new KeyBindSetting.Builder()
         .name("Keybind to tp")
         .description("Cancels sending packets and sends you back to your original position.")
-        .defaultValue(Keybind.none())
+        .defaultValue(KeyBind.none())
         .action(() -> {
+            if (mc.world == null || mc.player == null) return;   // just to fix a waring
             Camera camera = mc.gameRenderer.getCamera();
             Vec3d cameraPos = camera.getPos();
             float pitch = camera.getPitch();
@@ -68,21 +68,20 @@ public class PaperClickTp extends Module {
             Vec3d raycastEnd = cameraPos.add(rotationVec.multiply(300.0));
             BlockPos blockpos = mc.world.raycast(new RaycastContext(cameraPos, raycastEnd, RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.NONE, mc.player)).getBlockPos().up();
             Vec3d pos = new Vec3d((blockpos.getX() + .5), blockpos.getY(), (blockpos.getZ() + .5));
-            Thread waitForTickEventThread = new Thread(() -> {
-                new GotoUtil().moveto(pos.x, pos.y, pos.z);
-            });
+            Thread waitForTickEventThread = new Thread(() -> new GotoUtil().moveto(pos.x, pos.y, pos.z));
             waitForTickEventThread.start();
         })
         .build()
     );
 
-    public PaperClickTp(Category category, Item icon, String name, String description) {
+    public PaperClickTp() {
         super(Categories.Player, Items.DIAMOND, "PaperClickTp", "Teleports you to the block you are looking at on paper servers.");
     }
 
 
     @EventHandler
     private void onRender(Render3DEvent event) {
+        assert mc.player != null && mc.world != null;   // to fix Intellij's stupid warnings
         Camera camera = mc.gameRenderer.getCamera();
         Vec3d cameraPos = camera.getPos();
         float pitch = camera.getPitch();
@@ -104,4 +103,3 @@ public class PaperClickTp extends Module {
         }
     }
 }
-*/


### PR DESCRIPTION
This was a very simple bug: the keybind setting is spelled like Key*B*indSetting instead of Key*b*indSetting, and since java classes are case-sensitive it couldn't find the right class. This only took a few minutes to fix, including getting rid of some warnings (literally getting git to work took the longest)